### PR TITLE
Web SDK 109115 changes:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-web-sdk",
-  "version": "109114",
+  "version": "109115",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {},

--- a/src/bell/Button.js
+++ b/src/bell/Button.js
@@ -133,5 +133,8 @@ export default class Button extends ActiveAnimatedElement {
   pulse() {
     removeDomElement('.pulse-ring');
     addDomElement(this.element, 'beforeend', '<div class="pulse-ring"></div>');
+    if (this.bell.options.colors && this.bell.options.colors['pulse.color']) {
+      this.bell.button.element.querySelector('.pulse-ring').style.cssText = `border-color: ${this.bell.options.colors['pulse.color']} !important`;
+    }
   }
 }

--- a/src/bell/bell.scss
+++ b/src/bell/bell.scss
@@ -621,6 +621,7 @@ $sizes: (
 @-webkit-keyframes pulse {
     0% {
         -webkit-transform: scale(0.1);
+        transform: scale(0.1);
         opacity: 0.0;
         border-width: 10px;
     }
@@ -630,6 +631,7 @@ $sizes: (
     }
     100% {
         -webkit-transform: scale(1.2);
+        transform: scale(1.2);
         opacity: 0.0;
         border-width: 1px;
     }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1283,7 +1283,13 @@ var OneSignal = {
             if (manifestParentTagname !== 'head') {
               log.error(`OneSignal: Your manifest %c${manifestHtml}`, getConsoleStyle('code'), `must be referenced in the <head> tag to be detected properly. It is currently referenced in <${manifestParentTagname}>. (See: https://documentation.onesignal.com/docs/website-sdk-installation#3-include-and-initialize-the-sdk)`);
             } else {
-              log.error(`OneSignal: Please check your manifest at ${manifestLocation}. The %cgcm_sender_id`, getConsoleStyle('code'), "field is missing or invalid. (See: https://documentation.onesignal.com/docs/website-sdk-installation#2-upload-required-files)");
+              let manifestLocationOrigin = new URL(manifestLocation).origin;
+              let currentOrigin = location.origin;
+              if (currentOrigin !== manifestLocationOrigin) {
+                log.error(`OneSignal: Your manifest is being served from ${manifestLocationOrigin}, which is different from the current page's origin of ${currentOrigin}. Please serve your manifest from the same origin as your page's. If you are using a content delivery network (CDN), please add an exception so that the manifest is not served by your CDN. (See: https://documentation.onesignal.com/docs/website-sdk-installation#2-upload-required-files)`);
+              } else {
+                log.error(`OneSignal: Please check your manifest at ${manifestLocation}. The %cgcm_sender_id`, getConsoleStyle('code'), "field is missing or invalid. (See: https://documentation.onesignal.com/docs/website-sdk-installation#2-upload-required-files)");
+              }
             }
           } else if (location.protocol === 'https:') {
             log.error(`OneSignal: You must reference a %cmanifest.json`, getConsoleStyle('code'), "in <head>. (See: https://documentation.onesignal.com/docs/website-sdk-installation#2-upload-required-files)");


### PR DESCRIPTION
- Allow customization of notify button's main button colors
    - Can customize badge colors
    - Cannot customize text hover popup colors
    - Cannot customize dialog popup colors
- Add detection when manifest.json is served from a different origin (e.g. a CDN)
    - Throws a friendly error message on the console

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/13)
<!-- Reviewable:end -->
