### PR TITLE
Allow almost valid subdomains to be used in initializing the SDK.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -363,3 +363,22 @@ export function trimUndefined(object) {
   }
   return object;
 }
+
+/**
+ * Returns the correct subdomain if 'https://subdomain.onesignal.com' or something similar is passed.
+ */
+export function normalizeSubdomain(subdomain) {
+  subdomain = subdomain.trim();
+  let removeSubstrings = [
+    'http://www.',
+    'https://www.',
+    'http://',
+    'https://',
+    '.onesignal.com/',
+    '.onesignal.com'
+  ];
+  for (let removeSubstring of removeSubstrings) {
+    subdomain = subdomain.replace(removeSubstring, '');
+  }
+  return subdomain;
+}

--- a/test/entry.js
+++ b/test/entry.js
@@ -2,4 +2,9 @@ function importTestsThatRequireValidSubscription() {
   require('./subscribed-tests.js');
 }
 
+function importTestsThatDontRequireValidSubscription() {
+  require('./unsubscribed-tests.js');
+}
+
 window.importTestsThatRequireValidSubscription = importTestsThatRequireValidSubscription;
+window.importTestsThatDontRequireValidSubscription = importTestsThatDontRequireValidSubscription;

--- a/test/unsubscribed-tests.js
+++ b/test/unsubscribed-tests.js
@@ -1,0 +1,43 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import StackTrace from 'stacktrace-js';
+import log from 'loglevel';
+import { guid, delay, isPushNotificationsSupported, isPushNotificationsSupportedAndWarn, logError } from '../src/utils.js';
+import {APP_ID, PLAYER_ID} from './vars.js';
+
+chai.use(chaiAsPromised);
+
+describe('sdk.js', function(done) {
+  describe('Environment', () => {
+    it('isPushNotificationsSupported() should return true', () => {
+      expect(isPushNotificationsSupported()).to.be.true;
+    });
+
+    it('isPushNotificationsSupportedAndWarn() should return true', () => {
+      expect(isPushNotificationsSupportedAndWarn()).to.be.true;
+    });
+  })
+
+  describe('SDK Initialization', () => {
+    describe('Subdomain', () => {
+      it('valid subdomains should have the proper subdomain extracted', () => {
+        let validSubdomains = [
+          'subdomain',
+          '  subdomain  ',
+          'https://subdomain.onesignal.com',
+          'https://subdomain.onesignal.com/',
+          'http://www.subdomain.onesignal.com',
+          'https://www.subdomain.onesignal.com/',
+          'http://subdomain.onesignal.com',
+          'http://subdomain.onesignal.com/',
+          'subdomain.onesignal.com',
+          ];
+        let expectedNormalizedSubdomain = 'subdomain';
+        for (let validSubdomain of validSubdomains) {
+          let actualNormalizedSubdomain = OneSignal._init_getNormalizedSubdomain(validSubdomain);
+          expect(actualNormalizedSubdomain).to.equal(expectedNormalizedSubdomain);
+        }
+      });
+    });
+  })
+});


### PR DESCRIPTION
- e.g. ('https://subdomain.onesignal.com')

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/17)
<!-- Reviewable:end -->
