### PR TITLE
Web SDK 109129 changes:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-web-sdk",
-  "version": "109120",
+  "version": "109129",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {},

--- a/src/database.js
+++ b/src/database.js
@@ -1,5 +1,6 @@
 import log from 'loglevel';
 import Event from './events.js';
+import { getConsoleStyle } from './utils.js';
 
 
 export default class Database {
@@ -181,10 +182,82 @@ export default class Database {
       Database.get('Ids', 'registrationId'),
       Database.get('Ids', 'userId')
     ]).then(function(contents) {
-      log.info('appId:', contents[0]);
-      log.info('registrationId:', contents[1]);
-      log.info('userId:', contents[2]);
+      console.info('appId:', contents[0]);
+      console.info('registrationId:', contents[1]);
+      console.info('userId:', contents[2]);
     });
+  }
+
+  static printPushLog() {
+    Database.get('Options', 'pushLog')
+      .then(pushLogResult => {
+        if (pushLogResult) {
+          console.info('Push Log:', pushLogResult.value);
+        } else {
+          console.info('No push log found.');
+        }
+      })
+  }
+
+  static getPushLog() {
+    return new Promise(resolve => {
+      Database.get('Options', 'pushLog')
+        .then(pushLogResult => {
+          if (pushLogResult) {
+            if (typeof window !== 'undefined') {
+              window.pushlog = pushLogResult.value;
+            } else {
+              self.pushlog = pushLogResult.value;
+            }
+            console.info(`Push log stored in variable %cpushlog`, getConsoleStyle('code'), ".");
+            resolve(pushLogResult.value);
+          } else {
+            log.info('No push log found.');
+            resolve(null);
+          }
+        })
+    });
+  }
+
+  static clearPushLog() {
+    Database.put('Options', {key: 'pushLog', value: {}})
+      .then(() => console.info('Push log cleared.'));
+  }
+
+  static copyPushLog() {
+    Database.get('Options', 'pushLog')
+      .then(pushLogResult => {
+        if (pushLogResult) {
+          if (typeof window !== 'undefined') {
+            window.pushlog = pushLogResult.value;
+            console.info(`Push log set into variable. Please run this code now to copy the push log to your clipboard: %ccopy(window.pushlog)`, getConsoleStyle('code'), ". You should see 'undefined' but the contents will be copied to your clipboard.");
+          } else {
+            self.pushlog = pushLogResult.value;
+            console.info(`Push log set into variable. Please run this code now to copy the push log to your clipboard: %ccopy(self.pushlog)`, getConsoleStyle('code'));
+          }
+        } else {
+          console.warn('No push log found.');
+        }
+      })
+  }
+
+  static readPushLog(pushLog) {
+    if (!pushLog || pushLog == '') {
+      console.warn('Please pass in the entire stringified push log as a parameter. Example usage: %cOneSignal.database.readPushLog(`{ "ff5fb87e-40d9-4232-8df8-9300f3a0feaf": { "retrieved": "2016-02-24T05:43:25.705Z", "displayed": "2016-02-24T05:43:25.709Z" }}`)', getConsoleStyle('code'));
+      return;
+    }
+    var pushLog = JSON.parse(pushLog);
+    var pushLogKeys = Object.keys(pushLog);
+    var actions = ['retrieved', 'displayed', 'clicked'];
+    for (var key of pushLogKeys) {
+      for (var action of actions) {
+        if (pushLog[key][action]) {
+          // Convert string date to Date object
+          pushLog[key][action] = new Date(pushLog[key][action]);
+        }
+      }
+    }
+    return pushLog;
   }
 
   static _wipeBetaSettings() {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1031,7 +1031,7 @@ var OneSignal = {
                           OneSignal._registerServiceWorker(sw_path + OneSignal.SERVICE_WORKER_PATH);
                       }
                       else
-                        OneSignal._registerServiceWorker(sw_path + OneSignal.SERVICE_WORKER_PATH);
+                        OneSignal._registerServiceWorker(sw_path + OneSignal.SERVICE_WORKER_UPDATER_PATH);
 
                     })
                     .catch(function (e) {
@@ -1051,7 +1051,7 @@ var OneSignal = {
                           OneSignal._registerServiceWorker(sw_path + OneSignal.SERVICE_WORKER_UPDATER_PATH);
                       }
                       else
-                        OneSignal._registerServiceWorker(sw_path + OneSignal.SERVICE_WORKER_UPDATER_PATH);
+                        OneSignal._registerServiceWorker(sw_path + OneSignal.SERVICE_WORKER_PATH);
                     })
                     .catch(function (e) {
                       log.error(e);


### PR DESCRIPTION
- Service worker now logs last 500 pushes (time displayed, retrieved, and clicked) for better retroactive investigating
- Fix: If the stored service worker version is somehow missing from IndexedDB, a new service worker will be correctly installed. Previously, the user would be in a stuck state forever with the old service worker version.
- Welcome notifications are no longer persisted (i.e. they auto dismiss in 20 seconds now)
- Add the current user ID to all webhook request payloads

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/19)
<!-- Reviewable:end -->
