### PR TITLE
Add option to skip service worker refetching for Firefox v44.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesignal-web-sdk",
   "version": "1.0.0",
-  "sdkVersion": "109152",
+  "sdkVersion": "109154",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -606,6 +606,12 @@ var OneSignal = {
     }
     Promise.all(webhookPromises);
 
+    if (OneSignal._initOptions.serviceWorkerRefetchRequests === false) {
+      Database.put('Options', {key: 'serviceWorkerRefetchRequests', value: false})
+    } else {
+      Database.put('Options', {key: 'serviceWorkerRefetchRequests', value: true})
+    }
+
     // If Safari - add 'fetch' pollyfill if it isn't already added.
     if (isSupportedSafari() && typeof window.fetch == "undefined") {
       var s = document.createElement('script');

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -48,7 +48,7 @@ class ServiceWorker {
     if (Browser.firefox && Browser.version && contains(Browser.version, '44')) {
       Database.get('Options', 'serviceWorkerRefetchRequests')
         .then(refetchRequestsResult => {
-          if (refetchRequestsResult.value == true) {
+          if (refetchRequestsResult && refetchRequestsResult.value == true) {
             log.info('Detected Firefox v44; installing fetch handler to refetch all requests.');
             self.REFETCH_REQUESTS = true;
             self.addEventListener('fetch', ServiceWorker.onFetch);


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/30)
<!-- Reviewable:end -->
