### PR TITLE
Notification click event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesignal-web-sdk",
   "version": "1.0.0",
-  "sdkVersion": "109156",
+  "sdkVersion": "109157",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesignal-web-sdk",
   "version": "1.0.0",
-  "sdkVersion": "109151",
+  "sdkVersion": "109154",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -352,7 +352,7 @@ var OneSignal = {
               log.debug(`%c${Environment.getEnv().capitalize()} ⬸ ServiceWorker:`, getConsoleStyle('serviceworkermessage'), data, context);
             });
             OneSignal._channel.on('notification.clicked', function handler(context, data) {
-              OneSignal._fireNotificationOpenedCallbacks(data);
+              OneSignal._fireTransmittedNotificationClickedCallbacks(data);
             });
             log.info('Service worker messaging channel established!');
           }
@@ -601,6 +601,12 @@ var OneSignal = {
       webhookPromises.push(Database.put('Options', {key: `webhooks.cors`, value: false}));
     }
     Promise.all(webhookPromises);
+
+    if (OneSignal._initOptions.notificationClickHandlerMatch) {
+      Database.put('Options', {key: 'notificationClickHandlerMatch', value: OneSignal._initOptions.notificationClickHandlerMatch})
+    } else {
+      Database.put('Options', {key: 'notificationClickHandlerMatch', value: 'exact'})
+    }
 
     // If Safari - add 'fetch' pollyfill if it isn't already added.
     if (isSupportedSafari() && typeof window.fetch == "undefined") {
@@ -1141,7 +1147,7 @@ var OneSignal = {
         log.debug(`%c${Environment.getEnv().capitalize()} ⬸ ServiceWorker:`, getConsoleStyle('serviceworkermessage'), data, context);
       });
       OneSignal._channel.on('notification.clicked', function handler(context, data) {
-        OneSignal._fireNotificationOpenedCallbacks(data);
+        OneSignal._fireTransmittedNotificationClickedCallbacks(data);
       });
       log.info('Service worker channel now established!');
 
@@ -1564,14 +1570,7 @@ var OneSignal = {
       OneSignal._triggerEvent_nativePromptPermissionChanged(permissionBeforePrompt, event.data.httpNativePromptPermissionChanged);
     }
     else if (OneSignal.openedNotification) { // HTTP and HTTPS
-      OneSignal._fireNotificationOpenedCallbacks(event,data);
-    }
-  },
-
-  _fireNotificationOpenedCallbacks: function(data) {
-    while (OneSignal._notificationOpenedCallbacks.length > 0) {
-      let callback = OneSignal._notificationOpenedCallbacks.pop();
-      callback(data);
+      OneSignal._fireTransmittedNotificationClickedCallbacks(event,data);
     }
   },
 
@@ -1582,16 +1581,43 @@ var OneSignal = {
     }
 
     OneSignal._notificationOpenedCallbacks.push(callback);
-    if (Environment.isBrowser()) {
-      Database.get("NotificationOpened", document.URL)
-        .then(notificationOpenedResult => {
-          if (notificationOpenedResult) {
-            Database.remove("NotificationOpened", document.URL);
-            OneSignal._fireNotificationOpenedCallbacks(notificationOpenedResult.data);
-          }
-        })
-        .catch(e => log.error(e));
+    OneSignal._fireSavedNotificationClickedCallbacks();
+  },
+
+  _fireTransmittedNotificationClickedCallbacks: function(data) {
+    for (let notificationOpenedCallback of OneSignal._notificationOpenedCallbacks) {
+      notificationOpenedCallback(data);
     }
+  },
+
+  _fireSavedNotificationClickedCallbacks: function() {
+    Database.get("NotificationOpened", document.URL)
+      .then(notificationOpenedResult => {
+        if (notificationOpenedResult) {
+          Database.remove("NotificationOpened", document.URL);
+          let notificationData = notificationOpenedResult.data;
+          let timestamp = notificationOpenedResult.timestamp;
+          let discardNotification = false;
+          // 3/4: Timestamp is a new feature and previous notification opened results don't have it
+          if (timestamp) {
+            let now = Date.now();
+            let diffMilliseconds = Date.now() - timestamp;
+            let diffMinutes = diffMilliseconds / 1000 / 60;
+            /*
+             When the notification is clicked, its data is saved to IndexedDB, a new tab is opened, which then retrieves the just-saved data and runs this code.
+              If more than 5 minutes has passed, the page is probably being opened a long time later; do not fire the notification click event.
+              */
+            discardNotification = diffMinutes > 5;
+          }
+          if (discardNotification)
+            return;
+
+          for (let notificationOpenedCallback of OneSignal._notificationOpenedCallbacks) {
+            notificationOpenedCallback(notificationData);
+          }
+        }
+      })
+      .catch(e => log.error(e));
   },
 
   // Subdomain - Fired from message received from iframe.

--- a/src/vars.js
+++ b/src/vars.js
@@ -1,7 +1,7 @@
 import { isDev } from './utils.js';
 
-export const DEV_HOST = 'https://127.0.0.1:3001';
-export const DEV_FRAME_HOST = 'https://localhost:3001';
+export const DEV_HOST = 'https://oregon:3001';
+export const DEV_FRAME_HOST = 'https://nevada:3001';
 export const PROD_HOST = 'https://onesignal.com';
 export const HOST_URL = (isDev() ? DEV_HOST : PROD_HOST);
 export const API_URL = (isDev() ? DEV_HOST : PROD_HOST) + '/api/v1/';


### PR DESCRIPTION
The following are the changes to addListenerForNotificationOpened():

If `notificationClickHandlerMatch` is set to `exact` or omitted from OneSignal.init:
- One of any existing tabs exactly matching the notification's URL is focused and the event is fired on it

If `notificationClickHandlerMatch` is set to `origin`:
- As long as the URL opens to something on the same origin as the page, one of any existing tabs with the same origin is focused and the event is fired on it

In all cases, the event listener does not get destroyed after the first listen. However, in cases with multiple existing tabs, the event is always only fired on one of the tabs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/32)
<!-- Reviewable:end -->