### PR TITLE
Get extra subscription info for new push protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesignal-web-sdk",
   "version": "1.2.0",
-  "sdkVersion": "109250",
+  "sdkVersion": "109300",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {


### PR DESCRIPTION
Firefox 46+ and Chrome 50+ support the new encrypted web push protocol.
We obtain and forward the two parameters 'auth' and 'p256dh', both a
member of the PushSubscription object we obtain from
PushManager.subscribe(), to OneSignal. Firefox 44 & 45 do not support
the 'auth' property so we only forward each property if it exists.
Chrome < 50 does not support either 'auth' or 'p256dh'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/41)
<!-- Reviewable:end -->
