### PR TITLE
Add notify button display predicate

### DIFF
--- a/src/OneSignal.js
+++ b/src/OneSignal.js
@@ -169,8 +169,21 @@ export default class OneSignal {
         objectAssign(OneSignal.config.bell, OneSignal.config.notifyButton);
         objectAssign(OneSignal.config.notifyButton, OneSignal.config.bell);
       }
-      OneSignal.notifyButton = new Bell(OneSignal.config.notifyButton);
-      OneSignal.notifyButton.create();
+      if (OneSignal.config.notifyButton.displayPredicate &&
+          typeof OneSignal.config.notifyButton.displayPredicate === "function") {
+        Promise.resolve(OneSignal.config.notifyButton.displayPredicate())
+            .then(predicateValue => {
+              if (predicateValue !== false) {
+                OneSignal.notifyButton = new Bell(OneSignal.config.notifyButton);
+                OneSignal.notifyButton.create();
+              } else {
+                log.debug('Notify button display predicate returned false so not showing the notify button.');
+              }
+            });
+      } else {
+        OneSignal.notifyButton = new Bell(OneSignal.config.notifyButton);
+        OneSignal.notifyButton.create();
+      }
     }
   }
 


### PR DESCRIPTION
Add a notify button init option that allows passing a display predicate
that hides the notify button if it resolves to false. Predicate accepts
returns of both promises and non-promise values.

For example:

```javascript
notifyButton: {
            prenotify: true,
            showCredit: false,
            size: 'medium',
            position: 'bottom-right',
            enable: true,
            displayPredicate: function() {
              return OneSignal.isPushNotificationsEnabled()
                      .then(function(isPushEnabled) {
                          /* The user is subscribed, so we want to return "false" to hide the notify button */
                          return !isPushEnabled;
                      });
            },
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/64)
<!-- Reviewable:end -->
