### PR TITLE
Add support for Yandex browser >= 15.12.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -55,6 +55,9 @@ export function isPushNotificationsSupported () {
   if (Browser.chrome && Number(Browser.version) >= 42)
     return true;
 
+  if (Browser.yandexbrowser && Number(Browser.version) >= 15.12)
+    return true;
+
   return false;
 }
 


### PR DESCRIPTION
The browser version number is a temporary placeholder (released Dec.
2015) while I figure out what version of Yandex first supported push
notifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/65)
<!-- Reviewable:end -->
