### PR TITLE
Recover from wiped IndexedDB if push signal is sent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesignal-web-sdk",
   "version": "1.2.0",
-  "sdkVersion": "109385",
+  "sdkVersion": "109390",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {

--- a/src/OneSignalHelpers.js
+++ b/src/OneSignalHelpers.js
@@ -7,7 +7,7 @@ import LimitStore from './limitStore.js';
 import Event from "./events.js";
 import Database from './database.js';
 import * as Browser from 'bowser';
-import { isPushNotificationsSupported, isPushNotificationsSupportedAndWarn, getConsoleStyle, once, guid, contains, normalizeSubdomain, decodeHtmlEntities, getUrlQueryParam } from './utils.js';
+import { isPushNotificationsSupported, isPushNotificationsSupportedAndWarn, getConsoleStyle, once, guid, contains, normalizeSubdomain, decodeHtmlEntities, getUrlQueryParam, getDeviceTypeForBrowser } from './utils.js';
 import objectAssign from 'object-assign';
 import EventEmitter from 'wolfy87-eventemitter';
 import heir from 'heir';
@@ -49,16 +49,6 @@ export default class OneSignalHelpers {
     }
   }
 
-  static getDeviceTypeForBrowser() {
-    if (Browser.chrome || Browser.yandexbrowser) {
-      return OneSignal.DEVICE_TYPES.CHROME;
-    } else if (Browser.firefox) {
-      return OneSignal.DEVICE_TYPES.FIREFOX;
-    } else if (Browser.safari) {
-      return OneSignal.DEVICE_TYPES.SAFARI;
-    }
-  }
-
   static beginTemporaryBrowserSession() {
     sessionStorage.setItem("ONE_SIGNAL_SESSION", true);
   }
@@ -78,7 +68,7 @@ export default class OneSignalHelpers {
    *          Saves the user ID and registration ID to the local web database after the response from OneSignal.
    */
   static registerWithOneSignal(appId, subscriptionInfo) {
-    let deviceType = OneSignalHelpers.getDeviceTypeForBrowser();
+    let deviceType = getDeviceTypeForBrowser();
     return Promise.all([
       OneSignal.getUserId(),
       OneSignal.getSubscription()

--- a/src/api.js
+++ b/src/api.js
@@ -28,6 +28,28 @@ export function apiCall(action, method, data) {
     });
 }
 
+/**
+ * Given a GCM or Firefox subscription endpoint or Safari device token, returns the user ID from OneSignal's server.
+ * Used if the user clears his or her IndexedDB database and we need the user ID again.
+ */
+export function getUserIdFromSubscriptionIdentifier(appId, deviceType, identifier) {
+  // Calling POST /players with an existing identifier returns us that player ID
+  return apiCall('players', 'POST', {
+    app_id: appId,
+    device_type: deviceType,
+    identifier: identifier
+  }).then(response => {
+    if (response && response.id) {
+      return response.id;
+    } else {
+      return null;
+    }
+  }).catch(e => {
+    log.error('Error getting user ID from subscription identifier:', e);
+    return null;
+  });
+}
+
 export function sendNotification(appId, playerIds, titles, contents, url, icon, data) {
   var params = {
     app_id: appId,

--- a/src/utils.js
+++ b/src/utils.js
@@ -145,6 +145,22 @@ export function on(targetSelectorOrElement, event, task) {
     throw new Error(`${targetSelectorOrElement} must be a CSS selector string or DOM Element object.`);
 }
 
+var DEVICE_TYPES = {
+  CHROME: 5,
+      SAFARI: 7,
+      FIREFOX: 8,
+};
+
+export function getDeviceTypeForBrowser() {
+  if (Browser.chrome || Browser.yandexbrowser) {
+    return DEVICE_TYPES.CHROME;
+  } else if (Browser.firefox) {
+    return DEVICE_TYPES.FIREFOX;
+  } else if (Browser.safari) {
+    return DEVICE_TYPES.SAFARI;
+  }
+}
+
 export function once(targetSelectorOrElement, event, task, manualDestroy=false) {
   if (!event) {
     log.error('Cannot call on() with no event: ', event);


### PR DESCRIPTION
If a user has their IndexedDB wiped, but the service worker is still
active, on Chrome and Firefox we will recover the user's ID based on the
subscription endpoint from OneSignal's server and retry receiving the
notification. If the recovery attempt fails, the user is unsubscribed
from push notifications so that he does not receive "New site updates"
messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-website-sdk/71)
<!-- Reviewable:end -->
